### PR TITLE
Fix sizing builder not providing base size to Sizing init function

### DIFF
--- a/lib/sizing_builder.dart
+++ b/lib/sizing_builder.dart
@@ -23,6 +23,7 @@ class SizingBuilder extends StatelessWidget {
           Sizing.init(
             constraints,
             systemFontScale: systemFontScale,
+            baseSize: baseSize,
           );
           return builder.call();
         }


### PR DESCRIPTION
This fixes issue with base size not working correctly when set on sizing builder